### PR TITLE
Fix package.json from main process

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "./src/electron.js",
   "scripts": {
-    "start": "concurrently \"tsc ./src/electron.ts -w\"  \"cross-env NODE_ENV=dev nodemon --exec \"\"wait-on http://localhost:3000 && electron src/electron.js\"\""
+    "start": "concurrently \"tsc ./src/electron.ts -w\"  \"cross-env NODE_ENV=dev nodemon --exec \"\"wait-on http://localhost:3000 && electron src/electron.js\""
   },
   "author": "nateshmbhat",
   "dependencies": {


### PR DESCRIPTION
Looks like the concurrently script has an extra quote which makes it break